### PR TITLE
Config endpoint to allow multiple configuration items saved put or recalled together…

### DIFF
--- a/app/libs/models.py
+++ b/app/libs/models.py
@@ -199,12 +199,15 @@ class AuthorIndex(BaseModel):
     authorIndex: AuthorIndexStruct
     
 #-------------------------------------------------------
-class ClientConfig(BaseModel):
+class ClientConfigItem(BaseModel):
     """
     Dictionary to hold client configuration settings as set by the client administrator
     """
     configName: str = Schema(None, title="Unique name (within client ID) to save and retrieve configuration")
     configSettings: dict = Schema({}, title="Dictionary with all configuration settings")
+
+class ClientConfigList(BaseModel):
+    configList: List[ClientConfigItem]
 
 #-------------------------------------------------------
 class MoreLikeThisItem(BaseModel):

--- a/app/tests/testClientConfigCrud.py
+++ b/app/tests/testClientConfigCrud.py
@@ -6,6 +6,8 @@ Tests of the new 2020-08-23 CRUD endpoints for storage of global admin configura
 """
 import unittest
 import requests
+import models
+import json
 
 from unitTestConfig import base_plus_endpoint_encoded, session_id, headers, session_id, UNIT_TEST_CLIENT_ID
 from localsecrets import API_KEY, API_KEY_NAME
@@ -26,18 +28,26 @@ headers = {f"client-session":f"{session_id}",
            API_KEY_NAME: API_KEY
            }
 
+test_config_name = "test_client_test"
+test_config_name_1 = f"{test_config_name}_1"
+test_config_name_2 = f"{test_config_name}_2"
+# test_config_name_strlist = f"{test_config_name_0}, {test_config_name_1}"
+config_settings_1 =  {"a": 1, "b": 2, "c": 8}
+config_settings_2 =  {"a": 2, "b": 4, "c": 8}
 
-testbody = {
-    "configName": "test_client_test_0",
-    "configSettings": {"a": 1, "b": 2, "c": 8}
+testbody1 = {
+    "configName": test_config_name_1,
+    "configSettings": config_settings_1
   }
 
 testbody2 = {
-    "configName": "test_client_test_0",
-    "configSettings": {"a": 2, "b": 4, "c": 8}
+    "configName": test_config_name_2,
+    "configSettings": config_settings_2
   }
 
-test_config_name = "test_client_test_0"
+testlist_single1 = {"configList": [testbody1]}
+testlist_single2 = {"configList": [testbody2]}
+testlist_double = {"configList": [testbody1, testbody2]}
 
 class TestClientConfig(unittest.TestCase):
     """
@@ -48,82 +58,163 @@ class TestClientConfig(unittest.TestCase):
     Some calls require a parameter with the config name.
     
     """   
-    def test_0_post(self):
-        """
-        """
-        import opasCentralDBLib
-
-        ocd = opasCentralDBLib.opasCentralDB()
-        # make sure it's not there:
-        ocd.del_client_config(UNIT_TEST_CLIENT_ID, test_config_name)
-        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
-        response = requests.post(full_URL, 
-                                 headers=headers,
-                                 json=testbody)
-        # Confirm that the request-response cycle completed successfully.
-        r = response.json()
-        print (r)
-        assert(response.ok == True)
-        assert (r == testbody)
-
-    def test_0_post_fail(self):
-        #  try to update -- Fail
-        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
-        response = requests.post(full_URL, 
-                                 headers=headers,
-                                 json=testbody2)
-        # Confirm that the request-response cycle completed successfully.
-        assert(response.ok == False)
-        assert(response.status_code == 409)
-
-    def test_1_del(self):
-        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
-        response = requests.delete(full_URL,
-                                   headers=headers,
-                                   params={'configname': test_config_name})
-        r = response.json()
-        print (r)
-        assert(response.ok == True)
-
-    def test_2_put_and_get(self):
+    def test_0_get(self):
         # save the settings
         full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
         response = requests.put(full_URL,
                                 headers=headers,
-                                json=testbody)
+                                json=testlist_double)
         # Confirm that the request-response cycle completed successfully.
         assert(response.ok == True)
-        print ("Put OK")
         r = response.json()
-        assert (r == testbody)
-        print ("Put Echo Testbody OK")
+        assert (r == testlist_double)
+        print ("Put OK: ", r)
+
+        # fetch one of the settings
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.get(full_URL,
+                                headers=headers,
+                                params={'configname': test_config_name_1})
+        assert(response.ok == True)
+        #print(headers["client-session"])
+        r = response.json()
+        assert (r == {'configList': [{'configName': test_config_name_1, 'configSettings': config_settings_1}]})
+        print ("Get OK: ", r)
+
+        # fetch both of the settings
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.get(full_URL,
+                                headers=headers,
+                                params={'configname': f"{test_config_name_1}, {test_config_name_2}"})
+        assert(response.ok == True)
+        #print(headers["client-session"])
+        r = response.json()
+        #assert (r == {'configList': [{'configName': 'test_client_test_1', 'configSettings': {'a': 1, 'b': 2, 'c': 8}}, {'configName': 'test_client_test_2', 'configSettings': {'a': 2, 'b': 4, 'c': 8}}]})
+        assert (r == {'configList': [{'configName': test_config_name_1, 'configSettings': config_settings_1}, {'configName': test_config_name_2, 'configSettings': config_settings_2}]})
+        print ("Get OK: ", r)
+
+    def test_0_post(self):
+        """
+        """
+        # make sure both are not there:
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.delete(full_URL,
+                                   headers=headers,
+                                   params={'configname': f"{test_config_name_1}, {test_config_name_2}"}
+                                   )
+
+        # now post the list 
+        response = requests.post(full_URL, 
+                                 headers=headers,
+                                 json=testlist_double)
+        # Confirm that the request-response cycle completed successfully.
+        assert(response.ok == True)
+        r = response.json()
+        assert (r == testlist_double)
+        print ("Post OK: ", r)
+
+    def test_2_put_and_get(self):
+        # save the settings (whole list)
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.put(full_URL,
+                                headers=headers,
+                                json=testlist_double)
+        # Confirm that the request-response cycle completed successfully.
+        assert(response.ok == True)
+        r = response.json()
+        assert (r == testlist_double)
+        print ("Put list OK: ", r)
 
         # Update the settings - Succeed
         full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
         response = requests.put(full_URL,
                                 headers=headers,
-                                json=testbody2)
+                                json=testlist_double)
         # Confirm that the request-response cycle completed successfully.
         assert(response.ok == True)
-        print ("Update Put OK")
+        print ("Update list Put OK: ", r)
 
-        # delete the settings
+        # get one of the settings
         full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
         response = requests.get(full_URL,
                                 headers=headers,
-                                params={'configname': "test_client_test_0"})
+                                params={'configname': f"{test_config_name_1}"})
         assert(response.ok == True)
-        print ("Get OK")
         r = response.json()
+        assert (r == {'configList': [{'configName': test_config_name_1, 'configSettings': config_settings_1}]})
+        print ("Get updated config1 from list OK: ", r)
 
+        # get the other settings
         full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.get(full_URL,
+                                headers=headers,
+                                params={'configname': f"{test_config_name_2}"})
+        assert(response.ok == True)
+        r = response.json()
+        print (r)
+        assert (r == {'configList': [{'configName': test_config_name_2, 'configSettings': config_settings_2}]})
+        print ("Get updated config2 from list OK: ", r)
+
+        # get both of the settings
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.get(full_URL,
+                                headers=headers,
+                                params={'configname': f"{test_config_name_1}, {test_config_name_2}"})
+        assert(response.ok == True)
+        r = response.json()
+        assert (r == {'configList': [{'configName': test_config_name_1, 'configSettings': config_settings_1}, {'configName': test_config_name_2, 'configSettings': config_settings_2}]})
+        print ("Get updated both configs from list OK: ", r)
+
+    def test_3_post_fail(self):
+        #  try to update -- Fail
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        response = requests.post(full_URL, 
+                                 headers=headers,
+                                 json=testlist_double)
+        # Confirm that the request-response cycle completed successfully.
+        assert(response.ok == False)
+        assert(response.status_code == 409)
+
+    def test_4_del_and_cleanup(self):
+        full_URL = base_plus_endpoint_encoded('/v2/Client/Configuration/')
+        # create test records, if not there
+        response = requests.put(full_URL,
+                                headers=headers,
+                                json=testlist_double)
+        # Confirm that the request-response cycle completed successfully.
+        assert(response.ok == True)
         response = requests.delete(full_URL,
                                    headers=headers,
-                                   params={'configname': test_config_name})
+                                   params={'configname': test_config_name_1})
         assert(response.ok == True)
         r = response.json()
-        print ("Delete OK")
+        #print (r)
+        assert (r == {'configList': [{'configName': test_config_name_1, 'configSettings': config_settings_1}]})
+        response = requests.delete(full_URL,
+                                   headers=headers,
+                                   params={'configname': test_config_name_2})
+        assert(response.ok == True)
+        r = response.json()
+        assert (r == {'configList': [{'configName': test_config_name_2, 'configSettings': config_settings_2}]})
+
+        # First create, then delete both at once
+        response = requests.put(full_URL,
+                                headers=headers,
+                                json=testlist_double)
+        # Confirm that the request-response cycle completed successfully.
+        assert(response.ok == True)
+        print ("Update list in order to test delete, Put OK: ", r)
         
+        response = requests.delete(full_URL,
+                                   headers=headers,
+                                   params={'configname': f"{test_config_name_1}, {test_config_name_2}"}
+                                  )
+        assert(response.ok == True)
+        r = response.json()
+        #print (r)
+        assert (r == {'configList': [{'configName': test_config_name_1, 'configSettings': config_settings_1}, {'configName': test_config_name_2, 'configSettings': config_settings_2}]})
+        print ("Update list Del OK: ", r)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Per client developer request, now config body is a models.ClientConfigList, and although each models.ClientConfigItem is stored separately, they can be saved, updated, deleted, or fetched in multiples (even though they are stored separately in the database, so they can be retrieved in arbitrary sets.

Closes #89