### PR TITLE
Sort metadata content returns to fix TopLeveling.

### DIFF
--- a/app/config/opasConfig.py
+++ b/app/config/opasConfig.py
@@ -290,6 +290,7 @@ def normalize_val(val, val_dict, default=None):
     
     return ret_val
 
+BIBLIO_TABLE = "api_biblioxml2"
 # Special relatedrx field name from Solr schema
 RELATED_RX_FIELDNAME = "art_qual"
 # standard confidence values with implied meaning

--- a/app/libs/models.py
+++ b/app/libs/models.py
@@ -157,9 +157,9 @@ class Biblioxml(BaseModel):
     ref_publisher: str = Field(None)
     ref_in_pep: bool = Field(False, title="Indicates this is a PEP reference")
     ref_exists: bool = Field(False, title="Indicates this ref link has been verified")
-    link_updated: bool = Field(False, title="Indicates whether the data was corrected during load. If so, may need to update DB.")
-    record_updated: bool = Field(False)
     link_updated: bool = Field(False, title="Indicates whether the data was corrected during load. If so, may need to update DB.  See link_source for method")
+    record_exists: bool = Field(False, title="This entry is in the biblioDB")
+    record_updated: bool = Field(False)
     skip_incremental_scans: Optional[bool] # Field(False, title="Use to skip for speed during normal scans. Can reset it (in bulk) for a full rescan--in that way it's different than NEVERMORE")
     skip_reason: str = Field(None)
     parsed_ref: Optional[object]

--- a/app/libs/opasArticleIDSupport.py
+++ b/app/libs/opasArticleIDSupport.py
@@ -262,7 +262,7 @@ class ArticleID(BaseModel):
             if volumeWildcardOverride != '':
                 self.art_vol_str = volumeWildcardOverride
                 
-            self.is_supplement = self.art_issue_alpha_code == "S"
+            self.is_supplement = self.art_issue_alpha_code == "S" and self.src_code != "FA"
                     
             # page info
             # page = self.articleInfo.get("page")

--- a/app/libs/opasXMLProcessor.py
+++ b/app/libs/opasXMLProcessor.py
@@ -437,8 +437,11 @@ def update_biblio_links(parsed_xml, artInfo, ocd, pretty_print=False, verbose=Fa
                 bib_entry.link_updated = True
                 ref = bib_entry.parsed_ref
                 
-            bib_updated_from_db = bib_entry.compare_to_database(ocd)
-            if bib_entry.link_updated:
+            bib_entry.compare_to_database(ocd)
+            if not bib_entry.record_exists:
+                ocd.save_ref_to_biblioxml_table(bib_entry)
+                bib_entry.record_exists = True
+            elif bib_entry.link_updated:
                 ret_val += 1
                 if bib_entry.link_updated: # update xml (not db, info was from db))
                     if bib_entry.ref_rx is None or not bib_entry.ref_exists:

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@
 __author__      = "Neil R. Shapiro"
 __copyright__   = "Copyright 2019-2022, Psychoanalytic Electronic Publishing"
 __license__     = "Apache 2.0"
-__version__     = "2023.0228/v2.2.014"   # Requires rename biblioxml table and views to (name)2
+__version__     = "2023.0302/v2.2.015"   # Requires rename biblioxml table and views to (name)2
 __status__      = "Development/Libs/Loader"  
 
 """

--- a/app/opasDataLoader/opasDataLoader.py
+++ b/app/opasDataLoader/opasDataLoader.py
@@ -7,7 +7,11 @@
 __author__      = "Neil R. Shapiro"
 __copyright__   = "Copyright 2023, Psychoanalytic Electronic Publishing"
 __license__     = "Apache 2.0"
+<<<<<<< Updated upstream
 __version__     = "2023.0222/v2.1.013"   # Requires update to api_biblioxml2 and views based on it.
+=======
+__version__     = "2023.0302/v2.1.015"   # Requires update to api_biblioxml2 and views based on it.
+>>>>>>> Stashed changes
 __status__      = "Development"
 
 # !!! IMPORTANT: Increment opasXMLProcessor version (if version chgd). It's written to the XML !!!
@@ -1091,7 +1095,8 @@ def main():
     
                         for ref in bibReferences:
                             bib_entry = opasBiblioSupport.BiblioEntry(art_id=artInfo.art_id, art_year=artInfo.art_year_int, ref_or_parsed_ref=ref)
-                            if bib_entry.link_updated or bib_entry.record_updated:
+                            # perhaps only check if it exists when compiling xml. That would be faster. For now, to update, let it check
+                            if bib_entry.link_updated or bib_entry.record_updated or not ocd.exists(table_name=opasConfig.BIBLIO_TABLE, where_conditional=f"art_id='{bib_entry.art_id}' AND ref_local_id='{bib_entry.ref_local_id}'"):
                                 ocd.save_ref_to_biblioxml_table(bib_entry)
     
                 # close the file, and do the next

--- a/app/opasDataLoader/opasDataLoader.py
+++ b/app/opasDataLoader/opasDataLoader.py
@@ -7,11 +7,7 @@
 __author__      = "Neil R. Shapiro"
 __copyright__   = "Copyright 2023, Psychoanalytic Electronic Publishing"
 __license__     = "Apache 2.0"
-<<<<<<< Updated upstream
-__version__     = "2023.0222/v2.1.013"   # Requires update to api_biblioxml2 and views based on it.
-=======
-__version__     = "2023.0302/v2.1.015"   # Requires update to api_biblioxml2 and views based on it.
->>>>>>> Stashed changes
+__version__     = "2023.0302/v2.1.016"   # Requires update to api_biblioxml2 and views based on it.
 __status__      = "Development"
 
 # !!! IMPORTANT: Increment opasXMLProcessor version (if version chgd). It's written to the XML !!!

--- a/app/tests/testCoreArticleID.py
+++ b/app/tests/testCoreArticleID.py
@@ -70,6 +70,7 @@ class TestArticleID(unittest.TestCase):
         # Version 2 style, better, including sourcetype support
         # ---------------------------------------------------------------------------------------
         testIDs = [
+            ("FA.001S.R0001", 19),
             ("GW.018S.0000A", None), # (ArticleID, Expected issue number)
             ("IJP.034S.0005A", None),
             ("FA.002S.R0001", None),
@@ -77,7 +78,6 @@ class TestArticleID(unittest.TestCase):
             ("FA.001C.0074", 3), 
             ("FA.001F.R0001", 6),
             ("FA.001W.0062A", 23), 
-            ("FA.001S.R0001", 19),
             ("ajp.034.0155A", None), 
             ("PEPGRANTVS.001.0003A", None),
             ("PEPGRANTVS.001A.0015A", 1), 
@@ -91,7 +91,7 @@ class TestArticleID(unittest.TestCase):
             # test return
             r = response.json()
             a = ArticleID(**r)
-            if a.is_supplement:
+            if a.is_supplement and a.src_code != "FA":
                 assert(a.art_issue_int is None)
             else:
                 assert(a.art_issue_int == n[1]),  print (n, " = ", r)


### PR DESCRIPTION
Fixed metadata contents to sort roman sections first. Although if asking for multiple issues, all roman pages are at the front, when the client sorts by issue it all works out.