### PR TITLE
2023.0515/v2.3.020

### DIFF
--- a/app/libs/models.py
+++ b/app/libs/models.py
@@ -81,7 +81,8 @@ class ReportTypeEnum(str, Enum):
     userSearches = "User-Searches"
     documentViews = "Document-View-Stat"
     documentViewLog = "Document-View-Log"
-    characterCounts = "Character Count Report"
+    characterCounts = "Character-Count-Report"
+    characterCountsDetails = "Character-Count-Details-Report"
     #opasLogs = "Opas-Error-Logs"
     
 class TermTypeIDEnum(str, ExtendedEnum):

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@
 __author__      = "Neil R. Shapiro"
 __copyright__   = "Copyright 2019-2023, Psychoanalytic Electronic Publishing"
 __license__     = "Apache 2.0"
-__version__     = "2023.0424/v2.3.019"   # removed v3 ExtendedSearch endpoint so new 2.3 compatibility bump
+__version__     = "2023.0515/v2.3.020"   # new admin char details report
 __status__      = "Development/Libs/Loader"  
 
 """
@@ -804,6 +804,7 @@ async def admin_reports(response: Response,
         header = ["document id",
                   "view type",
                   "view count"]
+        
     elif report == models.ReportTypeEnum.characterCounts:
         report_view = "vw_reports_charcounts"
         orderby_clause = f"ORDER BY jrnlgrpname {sortorder}"
@@ -816,6 +817,18 @@ async def admin_reports(response: Response,
                   "char count",
                   "no space char count", 
                   "up to year"
+                  ]
+    elif report == models.ReportTypeEnum.characterCountsDetails:
+        report_view = "vw_reports_charcounts_details"
+        orderby_clause = f"ORDER BY jrnlcode, year {sortorder}"
+        header = ["jrnlcode",
+                  "year",
+                  "vol",
+                  "char count",
+                  "no space char count",
+                  "article count",
+                  "earliest year", 
+                  "latest year"
                   ]
     else:
         report_view = None

--- a/app/tests/testPEPAdminReports.py
+++ b/app/tests/testPEPAdminReports.py
@@ -25,26 +25,6 @@ class TestReports(unittest.TestCase):
 
     #TODO: Later these will need to be done while logged in.
     
-    def test00_document_char_counts_report(self):
-        # note api_key is required, but already in headers
-        full_URL = base_plus_endpoint_encoded(f'/v2/Admin/Reports/Character%20Count%20Report?limit=100&offset=0&getfullcount=false&download=false')
-        response = requests.get(full_URL, headers=headers)
-        assert(response.ok == True)
-        # these don't get affected by the level.
-        r = response.json()
-        response_info = r["report"]["responseInfo"]
-        response_set = r["report"]["responseSet"]
-        assert(response_info["count"] >= 1)
-        assert(response_set[0]["row"]["jrnlgrpname"] == 'ADPSA')  # to validate content is in record
-        
-    def test00B_document_char_counts_report(self):
-        # note api_key is required, but already in headers
-        full_URL = base_plus_endpoint_encoded(f'/v2/Admin/Reports/Character%20Count%20Report?limit=100&offset=0&getfullcount=false&download=true')
-        response = requests.get(full_URL, headers=headers)
-        assert(response.ok == True)
-        content = response.headers['content-disposition']
-        print (content)
-        assert (content[0:10] == 'attachment')
 
     def test01_session_log_report_daterange(self):
         # note api_key is required, but already in headers
@@ -267,7 +247,37 @@ class TestReports(unittest.TestCase):
         response_set = r["report"]["responseSet"]
         assert(response_info["count"] >= 1)           
 
+    def test09a_document_char_counts_report(self):
+        # data return (non-download) version
+        # note api_key is required, but already in headers
+        full_URL = base_plus_endpoint_encoded(f'/v2/Admin/Reports/Character-Count-Report?limit=100&offset=0&getfullcount=false&download=false')
+        response = requests.get(full_URL, headers=headers)
+        assert(response.ok == True)
+        # these don't get affected by the level.
+        r = response.json()
+        response_info = r["report"]["responseInfo"]
+        response_set = r["report"]["responseSet"]
+        assert(response_info["count"] >= 1)
+        assert(response_set[0]["row"]["jrnlgrpname"] == 'ADPSA')  # to validate content is in record
+        
+    def test09b_document_char_counts_report_download(self):
+        # note api_key is required, but already in headers
+        full_URL = base_plus_endpoint_encoded(f'/v2/Admin/Reports/Character-Count-Report?getfullcount=false&download=true')
+        response = requests.get(full_URL, headers=headers)
+        assert(response.ok == True)
+        content = response.headers['content-disposition']
+        print (content)
+        assert (content[0:10] == 'attachment')
 
+    def test10a_document_char_counts_details_report_download(self):
+        # note api_key is required, but already in headers
+        full_URL = base_plus_endpoint_encoded(f'/v2/Admin/Reports/Character-Count-Details-Report?getfullcount=false&download=true')
+        response = requests.get(full_URL, headers=headers)
+        assert(response.ok == True)
+        content = response.headers['content-disposition']
+        print (content)
+        assert (content[0:10] == 'attachment')
+        
 if __name__ == '__main__':
     unittest.main()
     print ("Tests Complete.")


### PR DESCRIPTION
Add a report to return the details of the character count report for journals and books (merged) by year.
- admin char details report added;
- renamed prior char count report with '-' separators instead of ' ' for naming consistency.