### PR TITLE
Fix: Properly align build and deploy state

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,13 +16,11 @@ jobs:
     environment: production-vars
     outputs:
       aws_account_id: ${{ steps.set-outputs.outputs.aws_account_id}}
-      engineer_ips: ${{ steps.set-outputs.outputs.engineer_ips}}
     steps:
       - name: Set output
         id: set-outputs
         run: |
           echo "aws_account_id=${{ vars.AWS_ACCOUNT_ID }}" >> $GITHUB_OUTPUT
-          echo "engineer_ips=${{ vars.ENGINEER_IPS }}" >> $GITHUB_OUTPUT
 
   infrastructure:
     needs: [env]
@@ -37,5 +35,4 @@ jobs:
       ENV_VARS: "TF_VAR_account_id=${{ needs.env.outputs.aws_account_id }}\n\
         TF_VAR_build_id=${{ github.sha }}\n\
         TF_VAR_mysql_username=${{ secrets.MYSQL_USERNAME }}\n\
-        TF_VAR_mysql_password=${{ secrets.MYSQL_PASSWORD }}\n\
-        TF_VAR_engineer_ips=${{ needs.env.outputs.engineer_ips }}"
+        TF_VAR_mysql_password=${{ secrets.MYSQL_PASSWORD }}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,13 +16,11 @@ jobs:
     environment: staging-vars
     outputs:
       aws_account_id: ${{ steps.set-outputs.outputs.aws_account_id}}
-      engineer_ips: ${{ steps.set-outputs.outputs.engineer_ips}}
     steps:
       - name: Set output
         id: set-outputs
         run: |
           echo "aws_account_id=${{ vars.AWS_ACCOUNT_ID }}" >> $GITHUB_OUTPUT
-          echo "engineer_ips=${{ vars.ENGINEER_IPS }}" >> $GITHUB_OUTPUT
 
   infrastructure:
     needs: [env]
@@ -37,5 +35,4 @@ jobs:
       ENV_VARS: "TF_VAR_account_id=${{ needs.env.outputs.aws_account_id }}\n\
         TF_VAR_build_id=${{ github.sha }}\n\
         TF_VAR_mysql_username=${{ secrets.MYSQL_USERNAME }}\n\
-        TF_VAR_mysql_password=${{ secrets.MYSQL_PASSWORD }}\n\
-        TF_VAR_engineer_ips=${{ needs.env.outputs.engineer_ips }}"
+        TF_VAR_mysql_password=${{ secrets.MYSQL_PASSWORD }}"

--- a/app/main.py
+++ b/app/main.py
@@ -1182,7 +1182,6 @@ async def api_live_doc(api_key: APIKey = Depends(get_api_key)):
     response = get_swagger_ui_html(openapi_url="/v2/Api/OpenapiSpec", title="docs")
 
     return response
-    # Test change
 
 #-----------------------------------------------------------------------------
 @app.get("/v2/Api/OpenapiSpec", tags=["API documentation"], summary=opasConfig.ENDPOINT_SUMMARY_OPEN_API)

--- a/app/main.py
+++ b/app/main.py
@@ -1182,6 +1182,7 @@ async def api_live_doc(api_key: APIKey = Depends(get_api_key)):
     response = get_swagger_ui_html(openapi_url="/v2/Api/OpenapiSpec", title="docs")
 
     return response
+    # Test change
 
 #-----------------------------------------------------------------------------
 @app.get("/v2/Api/OpenapiSpec", tags=["API documentation"], summary=opasConfig.ENDPOINT_SUMMARY_OPEN_API)

--- a/app/opasDataLoader/opasDataLoader.py
+++ b/app/opasDataLoader/opasDataLoader.py
@@ -499,6 +499,7 @@ def file_is_same_as_in_solr(solrcore, filename, timestamp_str):
 
 #------------------------------------------------------------------------------------------------------
 def main():
+    # Test change
     
     global options  # so the information can be used in support functions
     

--- a/app/opasDataLoader/opasDataLoader.py
+++ b/app/opasDataLoader/opasDataLoader.py
@@ -499,7 +499,6 @@ def file_is_same_as_in_solr(solrcore, filename, timestamp_str):
 
 #------------------------------------------------------------------------------------------------------
 def main():
-    # Test change
     
     global options  # so the information can be used in support functions
     

--- a/app/opasDataLoader/opasDataLoader.py
+++ b/app/opasDataLoader/opasDataLoader.py
@@ -499,7 +499,7 @@ def file_is_same_as_in_solr(solrcore, filename, timestamp_str):
 
 #------------------------------------------------------------------------------------------------------
 def main():
-    
+    # New test change
     global options  # so the information can be used in support functions
     
     cumulative_file_time_start = time.time()

--- a/infra/modules/data-utility/build.tf
+++ b/infra/modules/data-utility/build.tf
@@ -1,17 +1,7 @@
 
 resource "null_resource" "build_data_utility_image" {
   triggers = {
-    localsecrets_etag             = data.aws_s3_object.localsecrets.etag
-    config_sha1                   = local.config_sha1
-    libs_sha1                     = local.libs_sha1
-    opasDataLoader_sha1           = local.opasDataLoader_sha1
-    opasDataUpdateStat_sha1       = local.opasDataUpdateStat_sha1
-    opasEndnoteExport_sha1        = local.opasEndnoteExport_sha1
-    opasGoogleMetadataExport_sha1 = local.opasGoogleMetadataExport_sha1
-    opasPushSettings_sha1         = local.opasPushSettings_sha1
-    opasSiteMapper_sha1           = local.opasSiteMapper_sha1
-    opasDatabaseArchival_sha1     = local.opasDatabaseArchival_sha1
-    fargate_sha1                  = local.fargate_sha1
+    content_hash = local.content_hash
   }
 
   provisioner "local-exec" {
@@ -19,9 +9,21 @@ resource "null_resource" "build_data_utility_image" {
     command     = <<-EOT
       aws s3 cp s3://pep-configuration/${var.env}/localsecrets.py app/config/localsecrets.py
       aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${var.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com
-      docker build --platform linux/amd64 -t ${local.container_name} -f dataUtility/Dockerfile  .
-      docker tag ${local.container_name} ${var.repository_url}:${local.container_name}
-      docker push ${var.repository_url}:${local.container_name}
+      if aws ecr describe-images --repository-name=${var.repository_name} --image-ids=imageTag=${local.image_tag} --region ${var.aws_region} 2>/dev/null; then
+        echo "Image ${local.image_tag} already exists in ECR, skipping build"
+      else
+        echo "Building new image ${local.image_tag}"
+        docker build --platform linux/amd64 \
+          --label "build_id=${var.build_id}" \
+          --label "content_hash=${local.content_hash}" \
+          -t ${local.image_tag} -f dataUtility/Dockerfile .
+        docker tag ${local.image_tag} ${var.repository_url}:${local.image_tag}
+        docker push ${var.repository_url}:${local.image_tag}
+        
+        # Also tag with BUILD_ID for reference
+        docker tag ${local.image_tag} ${var.repository_url}:build-${var.build_id}
+        docker push ${var.repository_url}:build-${var.build_id}
+      fi
       rm -rf app/config/localsecrets.py
     EOT
   }

--- a/infra/modules/data-utility/locals.tf
+++ b/infra/modules/data-utility/locals.tf
@@ -12,5 +12,19 @@ locals {
 }
 
 locals {
-  container_name = "data-utility-${var.build_id}"
+  content_hash = substr(sha1(join("", [
+    local.config_sha1,
+    local.libs_sha1,
+    local.opasDataLoader_sha1,
+    local.opasDataUpdateStat_sha1,
+    local.opasEndnoteExport_sha1,
+    local.opasGoogleMetadataExport_sha1,
+    local.opasPushSettings_sha1,
+    local.opasSiteMapper_sha1,
+    local.opasDatabaseArchival_sha1,
+    local.fargate_sha1,
+    data.aws_s3_object.localsecrets.etag
+  ])), 0, 8)
+  image_tag = "data-utility-${local.content_hash}"
+  container_name = "data-utility"
 }

--- a/infra/modules/data-utility/task.tf
+++ b/infra/modules/data-utility/task.tf
@@ -5,7 +5,8 @@ resource "aws_ecs_task_definition" "data_utility" {
 
   depends_on = [null_resource.build_data_utility_image]
 
-  family = "${var.stack_name}-data-utility-${var.env}"
+  family       = "${var.stack_name}-data-utility-${var.env}"
+  skip_destroy = true
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"

--- a/infra/modules/data-utility/task.tf
+++ b/infra/modules/data-utility/task.tf
@@ -17,7 +17,7 @@ resource "aws_ecs_task_definition" "data_utility" {
   container_definitions = jsonencode([
     {
       name      = "main"
-      image     = "${var.repository_url}:${local.container_name}"
+      image     = "${var.repository_url}:${local.image_tag}"
       essential = true
       environment = [
         { NAME = "REPORT_BUCKET", VALUE = var.report_bucket },

--- a/infra/modules/data-utility/variables.tf
+++ b/infra/modules/data-utility/variables.tf
@@ -18,6 +18,10 @@ variable "repository_url" {
   description = "ECR repository URL"
 }
 
+variable "repository_name" {
+  description = "ECR repository name"
+}
+
 variable "cluster_arn" {
   description = "ECS cluster ARN"
 }

--- a/infra/modules/ecr/output.tf
+++ b/infra/modules/ecr/output.tf
@@ -2,6 +2,10 @@ output "repository_url" {
   value = aws_ecr_repository.opas_repository.repository_url
 }
 
+output "repository_name" {
+  value = aws_ecr_repository.opas_repository.name
+}
+
 output "ecr_execution_role_arn" {
   value = aws_iam_role.ecr_execution_role.arn
 }

--- a/infra/modules/rds/network.tf
+++ b/infra/modules/rds/network.tf
@@ -30,12 +30,19 @@ resource "aws_security_group" "db" {
   }
 
   ingress {
-    description     = "MySQL from PaDS"
+    description     = "MySQL from PaDS security group"
     from_port       = 3306
     to_port         = 3306
     protocol        = "tcp"
     security_groups = [var.pads_security_group_id]
-    cidr_blocks     = var.pads_ips
+  }
+
+  ingress {
+    description = "MySQL from PaDS IPs"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = var.pads_ips
   }
 
   ingress {

--- a/infra/modules/rds/network.tf
+++ b/infra/modules/rds/network.tf
@@ -16,10 +16,51 @@ resource "aws_db_subnet_group" "main" {
 }
 
 resource "aws_security_group" "db" {
-  name   = "${var.stack_name}-db-sg-${var.env}"
+  name = "${var.stack_name}-db-sg-${var.env}"
+
   vpc_id = var.vpc_id
 
-  # Outbound – allow everything
+  ingress {
+    description     = "MySQL from PaDS security group"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [var.pads_security_group_id]
+  }
+
+  ingress {
+    description = "MySQL from PaDS IPs"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = var.pads_ips
+  }
+
+  ingress {
+    description     = "MySQL from server"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [var.server_security_group_id]
+  }
+
+  ingress {
+    description     = "MySQL from data-utility"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [var.data_utility_group_id]
+  }
+
+  ingress {
+    description = "MySQL from self"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    self        = true
+  }
+
+
   egress {
     from_port        = 0
     to_port          = 0
@@ -33,103 +74,4 @@ resource "aws_security_group" "db" {
     stack = var.stack_name
     env   = var.env
   }
-}
-
-# GitLab Runner (to be deprecated)
-resource "aws_security_group_rule" "db_mysql_gitlab_runner" {
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from GitLab"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  cidr_blocks = [var.gitlab_runner_ip]
-}
-
-# PaDS security-group
-resource "aws_security_group_rule" "db_mysql_pads_sg" {
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from PaDS security group"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  source_security_group_id = var.pads_security_group_id
-}
-
-# PaDS IP allow-list
-resource "aws_security_group_rule" "db_mysql_pads_ips" {
-  for_each = toset(var.pads_ips)
-
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from PaDS IPs"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  cidr_blocks = [each.key]
-}
-
-# Application server security-group
-resource "aws_security_group_rule" "db_mysql_server_sg" {
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from server"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  source_security_group_id = var.server_security_group_id
-}
-
-# Data-utility security-group
-resource "aws_security_group_rule" "db_mysql_data_utility_sg" {
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from data-utility"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  source_security_group_id = var.data_utility_group_id
-}
-
-# Self-reference
-resource "aws_security_group_rule" "db_mysql_self" {
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from self"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  self = true
-}
-
-# Engineer IPs
-locals {
-  engineer_cidrs = formatlist("%s/32", split(",", var.engineer_ips))
-}
-
-resource "aws_security_group_rule" "db_mysql_engineer_ips" {
-  for_each = toset(local.engineer_cidrs)
-
-  type              = "ingress"
-  security_group_id = aws_security_group.db.id
-
-  description = "MySQL from PEP engineer"
-  from_port   = 3306
-  to_port     = 3306
-  protocol    = "tcp"
-
-  cidr_blocks = [each.key]
 }

--- a/infra/modules/rds/network.tf
+++ b/infra/modules/rds/network.tf
@@ -16,67 +16,10 @@ resource "aws_db_subnet_group" "main" {
 }
 
 resource "aws_security_group" "db" {
-  name = "${var.stack_name}-db-sg-${var.env}"
-
+  name   = "${var.stack_name}-db-sg-${var.env}"
   vpc_id = var.vpc_id
 
-  // GitLab Runner - To be deprecated
-  ingress {
-    description = "MySQL from GitLab"
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
-    cidr_blocks = [var.gitlab_runner_ip]
-  }
-
-  ingress {
-    description     = "MySQL from PaDS security group"
-    from_port       = 3306
-    to_port         = 3306
-    protocol        = "tcp"
-    security_groups = [var.pads_security_group_id]
-  }
-
-  ingress {
-    description = "MySQL from PaDS IPs"
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
-    cidr_blocks = var.pads_ips
-  }
-
-  ingress {
-    description     = "MySQL from server"
-    from_port       = 3306
-    to_port         = 3306
-    protocol        = "tcp"
-    security_groups = [var.server_security_group_id]
-  }
-
-  ingress {
-    description     = "MySQL from data-utility"
-    from_port       = 3306
-    to_port         = 3306
-    protocol        = "tcp"
-    security_groups = [var.data_utility_group_id]
-  }
-
-  ingress {
-    description = "MySQL from self"
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
-    self        = true
-  }
-
-  ingress {
-    description = "MySQL from PEP engineer"
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", split(",", var.engineer_ips))
-  }
-
+  # Outbound – allow everything
   egress {
     from_port        = 0
     to_port          = 0
@@ -90,4 +33,103 @@ resource "aws_security_group" "db" {
     stack = var.stack_name
     env   = var.env
   }
+}
+
+# GitLab Runner (to be deprecated)
+resource "aws_security_group_rule" "db_mysql_gitlab_runner" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from GitLab"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  cidr_blocks = [var.gitlab_runner_ip]
+}
+
+# PaDS security-group
+resource "aws_security_group_rule" "db_mysql_pads_sg" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from PaDS security group"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  source_security_group_id = var.pads_security_group_id
+}
+
+# PaDS IP allow-list
+resource "aws_security_group_rule" "db_mysql_pads_ips" {
+  for_each = toset(var.pads_ips)
+
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from PaDS IPs"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  cidr_blocks = [each.key]
+}
+
+# Application server security-group
+resource "aws_security_group_rule" "db_mysql_server_sg" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from server"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  source_security_group_id = var.server_security_group_id
+}
+
+# Data-utility security-group
+resource "aws_security_group_rule" "db_mysql_data_utility_sg" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from data-utility"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  source_security_group_id = var.data_utility_group_id
+}
+
+# Self-reference
+resource "aws_security_group_rule" "db_mysql_self" {
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from self"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  self = true
+}
+
+# Engineer IPs
+locals {
+  engineer_cidrs = formatlist("%s/32", split(",", var.engineer_ips))
+}
+
+resource "aws_security_group_rule" "db_mysql_engineer_ips" {
+  for_each = toset(local.engineer_cidrs)
+
+  type              = "ingress"
+  security_group_id = aws_security_group.db.id
+
+  description = "MySQL from PEP engineer"
+  from_port   = 3306
+  to_port     = 3306
+  protocol    = "tcp"
+
+  cidr_blocks = [each.key]
 }

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -24,9 +24,6 @@ variable "vpc_id" {
   description = "VPC ID"
 }
 
-variable "gitlab_runner_ip" {
-  description = "IP of the GitLab runner"
-}
 
 variable "server_security_group_id" {
   description = "Security group ID for the server"
@@ -40,10 +37,6 @@ variable "availability_zone" {
   description = "Availability zone"
 }
 
-variable "engineer_ips" {
-  description = "IPs for PEP engineers (comma delimited)"
-  type        = string
-}
 
 variable "pads_ips" {
   description = "IP of the PaDS instances"

--- a/infra/modules/server/build.tf
+++ b/infra/modules/server/build.tf
@@ -1,8 +1,6 @@
 resource "null_resource" "build_server_image" {
   triggers = {
-    localsecrets_etag = data.aws_s3_object.localsecrets.etag
-    app_sha1          = local.app_sha1
-    dockerfile_sha1   = local.dockerfile_sha1
+    content_hash = local.content_hash
   }
 
   provisioner "local-exec" {
@@ -10,9 +8,21 @@ resource "null_resource" "build_server_image" {
     command     = <<-EOT
       aws s3 cp s3://pep-configuration/${var.env}/localsecrets.py app/config/localsecrets.py
       aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${var.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com
-      docker build --platform linux/amd64 -t ${local.container_name} -f ./Dockerfile  .
-      docker tag ${local.container_name} ${var.repository_url}:${local.container_name}
-      docker push ${var.repository_url}:${local.container_name}
+      if aws ecr describe-images --repository-name=${var.repository_name} --image-ids=imageTag=${local.image_tag} --region ${var.aws_region} 2>/dev/null; then
+        echo "Image ${local.image_tag} already exists in ECR, skipping build"
+      else
+        echo "Building new image ${local.image_tag}"
+        docker build --platform linux/amd64 \
+          --label "build_id=${var.build_id}" \
+          --label "content_hash=${local.content_hash}" \
+          -t ${local.image_tag} -f ./Dockerfile .
+        docker tag ${local.image_tag} ${var.repository_url}:${local.image_tag}
+        docker push ${var.repository_url}:${local.image_tag}
+        
+        # Also tag with BUILD_ID for reference
+        docker tag ${local.image_tag} ${var.repository_url}:build-${var.build_id}
+        docker push ${var.repository_url}:build-${var.build_id}
+      fi
       rm -rf app/config/localsecrets.py
     EOT
   }

--- a/infra/modules/server/locals.tf
+++ b/infra/modules/server/locals.tf
@@ -4,5 +4,7 @@ locals {
 }
 
 locals {
-  container_name = "server-${var.build_id}"
+  content_hash = substr(sha1("${local.app_sha1}-${local.dockerfile_sha1}-${data.aws_s3_object.localsecrets.etag}"), 0, 8)
+  image_tag = "server-${local.content_hash}"
+  container_name = "server"
 }

--- a/infra/modules/server/service.tf
+++ b/infra/modules/server/service.tf
@@ -5,7 +5,8 @@ resource "aws_ecs_task_definition" "server" {
     replace_triggered_by = [null_resource.build_server_image]
   }
 
-  family = "${var.stack_name}-server-${var.env}"
+  family       = "${var.stack_name}-server-${var.env}"
+  skip_destroy = true
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"

--- a/infra/modules/server/service.tf
+++ b/infra/modules/server/service.tf
@@ -18,7 +18,7 @@ resource "aws_ecs_task_definition" "server" {
   container_definitions = jsonencode([
     {
       name      = "main"
-      image     = "${var.repository_url}:${local.container_name}"
+      image     = "${var.repository_url}:${local.image_tag}"
       essential = true
       portMappings = [
         {

--- a/infra/modules/server/variables.tf
+++ b/infra/modules/server/variables.tf
@@ -18,6 +18,10 @@ variable "repository_url" {
   description = "ECR repository URL"
 }
 
+variable "repository_name" {
+  description = "ECR repository name"
+}
+
 variable "ecr_execution_role_arn" {
   description = "ECR execution role ARN"
 }

--- a/infra/modules/solr/build.tf
+++ b/infra/modules/solr/build.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "build_solr_image" {
   triggers = {
-    dockerfile_sha1 = local.dockerfile_sha1
+    content_hash = local.content_hash
   }
 
   provisioner "local-exec" {
@@ -8,9 +8,21 @@ resource "null_resource" "build_solr_image" {
 
     command = <<-EOT
       aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${var.account_id}.dkr.ecr.${var.aws_region}.amazonaws.com
-      docker build --platform linux/amd64 -t ${local.container_name} -f ./Dockerfile  .
-      docker tag ${local.container_name} ${var.repository_url}:${local.container_name}
-      docker push ${var.repository_url}:${local.container_name}
+      if aws ecr describe-images --repository-name=${var.repository_name} --image-ids=imageTag=${local.image_tag} --region ${var.aws_region} 2>/dev/null; then
+        echo "Image ${local.image_tag} already exists in ECR, skipping build"
+      else
+        echo "Building new image ${local.image_tag}"
+        docker build --platform linux/amd64 \
+          --label "build_id=${var.build_id}" \
+          --label "content_hash=${local.content_hash}" \
+          -t ${local.image_tag} -f ./Dockerfile .
+        docker tag ${local.image_tag} ${var.repository_url}:${local.image_tag}
+        docker push ${var.repository_url}:${local.image_tag}
+        
+        # Also tag with BUILD_ID for reference
+        docker tag ${local.image_tag} ${var.repository_url}:build-${var.build_id}
+        docker push ${var.repository_url}:build-${var.build_id}
+      fi
     EOT
   }
 }

--- a/infra/modules/solr/locals.tf
+++ b/infra/modules/solr/locals.tf
@@ -1,4 +1,6 @@
 locals {
   dockerfile_sha1 = filesha1("../../solrCoreConfigurations/Dockerfile")
-  container_name = "solr-${var.build_id}"
+  content_hash = substr(sha1(local.dockerfile_sha1), 0, 8)
+  image_tag = "solr-${local.content_hash}"
+  container_name = "solr"
 }

--- a/infra/modules/solr/service.tf
+++ b/infra/modules/solr/service.tf
@@ -5,7 +5,8 @@ resource "aws_ecs_task_definition" "solr" {
     replace_triggered_by = [null_resource.build_solr_image]
   }
 
-  family = "${var.stack_name}-solr-${var.env}"
+  family       = "${var.stack_name}-solr-${var.env}"
+  skip_destroy = true
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"

--- a/infra/modules/solr/service.tf
+++ b/infra/modules/solr/service.tf
@@ -1,6 +1,10 @@
 resource "aws_ecs_task_definition" "solr" {
   depends_on = [null_resource.build_solr_image]
 
+  lifecycle {
+    replace_triggered_by = [null_resource.build_solr_image]
+  }
+
   family = "${var.stack_name}-solr-${var.env}"
 
   requires_compatibilities = ["FARGATE"]
@@ -22,7 +26,7 @@ resource "aws_ecs_task_definition" "solr" {
   container_definitions = jsonencode([
     {
       name      = "main"
-      image     = "${var.repository_url}:${local.container_name}"
+      image     = "${var.repository_url}:${local.image_tag}"
       essential = true
       portMappings = [
         {

--- a/infra/modules/solr/variables.tf
+++ b/infra/modules/solr/variables.tf
@@ -18,6 +18,10 @@ variable "repository_url" {
   description = "ECR repository URL"
 }
 
+variable "repository_name" {
+  description = "ECR repository name"
+}
+
 variable "ecr_execution_role_arn" {
   description = "ECR execution role ARN"
 }

--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -113,7 +113,7 @@ module "database" {
   data_utility_group_id    = module.data_utility.security_group_id
   server_security_group_id = module.server.security_group_id
   availability_zone        = "us-east-1f"
-  pads_security_group_id   = "sg-082ec49ff5d9e76cb"
+  pads_security_group_id   = "631911044226/sg-082ec49ff5d9e76cb"
   pads_ips                 = ["52.200.214.35/32", "34.202.154.34/32"]
 
   # Aurora Serverless v2 settings

--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -112,9 +112,7 @@ module "database" {
   vpc_id                   = module.vpc.vpc_id
   data_utility_group_id    = module.data_utility.security_group_id
   server_security_group_id = module.server.security_group_id
-  gitlab_runner_ip         = "54.210.185.163/32"
   availability_zone        = "us-east-1f"
-  engineer_ips             = var.engineer_ips
   pads_security_group_id   = "sg-082ec49ff5d9e76cb"
   pads_ips                 = ["52.200.214.35/32", "34.202.154.34/32"]
 

--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -55,6 +55,7 @@ module "data_utility" {
   account_id             = var.account_id
   aws_region             = var.aws_region
   repository_url         = module.ecr.repository_url
+  repository_name        = module.ecr.repository_name
   cluster_arn            = module.ecs.cluster_arn
   vpc_id                 = module.vpc.vpc_id
   ecr_execution_role_arn = module.ecr.ecr_execution_role_arn
@@ -89,6 +90,7 @@ module "server" {
   account_id             = var.account_id
   aws_region             = var.aws_region
   repository_url         = module.ecr.repository_url
+  repository_name        = module.ecr.repository_name
   ecr_execution_role_arn = module.ecr.ecr_execution_role_arn
   cluster_arn            = module.ecs.cluster_arn
   vpc_id                 = module.vpc.vpc_id
@@ -170,6 +172,7 @@ module "solr" {
   account_id               = var.account_id
   aws_region               = var.aws_region
   repository_url           = module.ecr.repository_url
+  repository_name          = module.ecr.repository_name
   ecr_execution_role_arn   = module.ecr.ecr_execution_role_arn
   cluster_arn              = module.ecs.cluster_arn
   vpc_id                   = module.vpc.vpc_id

--- a/infra/production/variables.tf
+++ b/infra/production/variables.tf
@@ -37,11 +37,6 @@ variable "mysql_password" {
   sensitive   = true
 }
 
-variable "engineer_ips" {
-  description = "IPs for PEP engineers (comma delimited)"
-  sensitive   = true
-  type        = string
-}
 
 variable "build_id" {
   description = "Unique build identifier"

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -55,6 +55,7 @@ module "data_utility" {
   account_id             = var.account_id
   aws_region             = var.aws_region
   repository_url         = module.ecr.repository_url
+  repository_name        = module.ecr.repository_name
   cluster_arn            = module.ecs.cluster_arn
   vpc_id                 = module.vpc.vpc_id
   ecr_execution_role_arn = module.ecr.ecr_execution_role_arn
@@ -88,6 +89,7 @@ module "server" {
   account_id             = var.account_id
   aws_region             = var.aws_region
   repository_url         = module.ecr.repository_url
+  repository_name        = module.ecr.repository_name
   ecr_execution_role_arn = module.ecr.ecr_execution_role_arn
   cluster_arn            = module.ecs.cluster_arn
   vpc_id                 = module.vpc.vpc_id
@@ -160,6 +162,7 @@ module "solr" {
   account_id               = var.account_id
   aws_region               = var.aws_region
   repository_url           = module.ecr.repository_url
+  repository_name          = module.ecr.repository_name
   ecr_execution_role_arn   = module.ecr.ecr_execution_role_arn
   cluster_arn              = module.ecs.cluster_arn
   vpc_id                   = module.vpc.vpc_id

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -112,7 +112,7 @@ module "database" {
   data_utility_group_id    = module.data_utility.security_group_id
   server_security_group_id = module.server.security_group_id
   availability_zone        = "us-east-1f"
-  pads_security_group_id   = "sg-082ec49ff5d9e76cb"
+  pads_security_group_id   = "631911044226/sg-082ec49ff5d9e76cb"
   pads_ips                 = ["54.211.127.208/32"]
   min_capacity             = 0.5
   max_capacity             = 1

--- a/infra/staging/main.tf
+++ b/infra/staging/main.tf
@@ -111,9 +111,7 @@ module "database" {
   vpc_id                   = module.vpc.vpc_id
   data_utility_group_id    = module.data_utility.security_group_id
   server_security_group_id = module.server.security_group_id
-  gitlab_runner_ip         = "54.210.185.163/32"
   availability_zone        = "us-east-1f"
-  engineer_ips             = var.engineer_ips
   pads_security_group_id   = "sg-082ec49ff5d9e76cb"
   pads_ips                 = ["54.211.127.208/32"]
   min_capacity             = 0.5

--- a/infra/staging/variables.tf
+++ b/infra/staging/variables.tf
@@ -37,11 +37,6 @@ variable "mysql_password" {
   sensitive   = true
 }
 
-variable "engineer_ips" {
-  description = "IPs for PEP engineers (comma delimited)"
-  sensitive   = true
-  type        = string
-}
 
 variable "build_id" {
   description = "Unique build identifier"

--- a/solrCoreConfigurations/Dockerfile
+++ b/solrCoreConfigurations/Dockerfile
@@ -8,3 +8,6 @@ USER solr
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]
+
+
+# New test change

--- a/solrCoreConfigurations/Dockerfile
+++ b/solrCoreConfigurations/Dockerfile
@@ -8,3 +8,5 @@ USER solr
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]
+
+# Test change

--- a/solrCoreConfigurations/Dockerfile
+++ b/solrCoreConfigurations/Dockerfile
@@ -8,5 +8,3 @@ USER solr
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["solr-foreground"]
-
-# Test change


### PR DESCRIPTION
## Summary
Implement content-based image tagging to prevent unnecessary rebuilds and phantom task definition updates.

## Changes
- Replace BUILD_ID with content hash in image tags
- Only rebuild when actual code changes occur
- Add ECR image existence checks
- Fix missing lifecycle rule in Solr module
- Preserve BUILD_ID as Docker labels for traceability

## Test plan
- [x] Deploy to staging and verify no unnecessary rebuilds on non-code commits
- [x] Verify each service only rebuilds when its specific files change
- [x] Test rollback capability using content-based tags